### PR TITLE
Incorporate dependencies and allow the script to be run directly

### DIFF
--- a/torbox-magnet-importer.py
+++ b/torbox-magnet-importer.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+
 import requests
 import logging
 from typing import List, Set


### PR DESCRIPTION
I was getting an error about a missing 'requests' dependency when trying to run the script.

I added a shebang and inline script metadata to allow uv to resolve the dependency. The script can now be run directly after making it executable.